### PR TITLE
Update Slack->Mattermost

### DIFF
--- a/doc/_templates/sidebar.html
+++ b/doc/_templates/sidebar.html
@@ -33,8 +33,8 @@
             bug</a>
         </li>
         <li class="nav-item">
-          <a target="_blank" href="https://softwareunderground.org/slack"><i class="fab fa-slack fa-fw"></i> #pyGIMLi
-            slack channel</a>
+          <a target="_blank" href="https://softwareunderground.org/mattermost"><i class="fab fa-slack fa-fw"></i> pyGIMLi
+            chat</a>
         </li>
         <li class="nav-item">
           <a href="{{ pathto('citation') }}"><i class="fas fa-quote-right fa-fw"></i> Citation</a>


### PR DESCRIPTION
There is no fa-mattermost unfortunately, so I left the fa-slack.

Also, I avoided the branding entirely, and just named it "chat" - feel free to adjust!
