### PR TITLE
Improve issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -79,7 +79,7 @@ body:
     attributes:
       label: Code to reproduce the issue
       description: Please provide the code that produces the error in the form of a minimal reproducible example. Alternatively, you can also attach the code as a file in the field below.
-      render: code
+      render: python
   - type: textarea
     id: reproduce-data
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -64,7 +64,7 @@ body:
     attributes:
       label: Problem description
       description: Please provide a general description of the issue here.
-      required: true
+    required: true
   - type: markdown
     attributes:
       value: "### Reproducing the issue"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -64,7 +64,8 @@ body:
     attributes:
       label: Problem description
       description: Please provide a general description of the issue here.
-    required: true
+    validations:
+      required: true
   - type: markdown
     attributes:
       value: "### Reproducing the issue"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,14 +7,6 @@ body:
       value: Thanks for taking the time to fill out this bug report! To facilitate efficient support, please fill out all the information applicable to your issue.
   - type: markdown
     attributes:
-      value: "### Problem description"
-  - type: textarea
-    id: problem-description
-    attributes:
-      label: Problem description
-      description: Please provide a general description of the issue here.
-  - type: markdown
-    attributes:
       value: "### Your environment"
   - type: textarea
     id: environment-report
@@ -66,6 +58,15 @@ body:
       description: If you have additional information on the environment or installation that did not fit the forms above, please enter it here.
   - type: markdown
     attributes:
+      value: "### Problem description"
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Problem description
+      description: Please provide a general description of the issue here.
+      required: true
+  - type: markdown
+    attributes:
       value: "### Reproducing the issue"
   - type: textarea
     id: reproduce-steps
@@ -77,7 +78,7 @@ body:
     attributes:
       label: Code to reproduce the issue
       description: Please provide the code that produces the error in the form of a minimal reproducible example. Alternatively, you can also attach the code as a file in the field below.
-      render: shell
+      render: code
   - type: textarea
     id: reproduce-data
     attributes:


### PR DESCRIPTION
This pull request is the start of improvements to the issue forms. So far, I have made the following changes:
- Moved the problem description below the environment section to clarify that the form contains multiple fields even on small screens
- Made the problem description required
- Fixed the code to reproduce rendering using the "python" class (I also tried "code" but it does not provide much syntax highlighting)

The following issues are still open:
- The drop-downs with possible Python and pyGIMLi versions need to be kept up to date, using an input field with regular expression validation would be better
- Making OS and Python version required but only if the output of pygimli.Report() is not provided

Unfortunately, it is currently not possible to do this with the issue form validation.

The forms can be tested [here](https://github.com/CamillaLu/gimli/issues).