### PR TITLE
Add options for specifying other versions in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -35,6 +35,7 @@ body:
         - 3.11
         - 3.10
         - 3.9
+        - Other version, please specify below
   - type: input
     id: way-of-installation
     attributes:
@@ -47,11 +48,13 @@ body:
       description: Output of `print(pygimli.__version__)`
       options:
         - 1.6.0
+        - 1.5.5
         - 1.5.4
         - 1.5.3
         - 1.5.2
         - 1.5.1
         - 1.5.0
+        - Other version, please specify below
   - type: textarea
     id: environment-additional
     attributes:


### PR DESCRIPTION
While testing Issue #946, it was observed that the user reported an inconsistency regarding the pyGIMLi version. Therefore, it might be nice to add version 1.5.5 to the drop-down menu as well.
